### PR TITLE
Skip move prompt when running in the app sandbox

### DIFF
--- a/Sources/LetsMoveSwiftly/LetsMoveSwiftly.swift
+++ b/Sources/LetsMoveSwiftly/LetsMoveSwiftly.swift
@@ -62,6 +62,7 @@ public enum LetsMoveSwiftly {
     /// Determines whether the app should offer to move to `/Applications/`.
     ///
     /// Returns `false` when any of these conditions are met:
+    /// - The app is running inside the macOS app sandbox (sandboxed apps cannot move themselves)
     /// - The app was installed from the Mac App Store (a valid receipt file exists on disk)
     /// - The app is already running from `/Applications/` or `~/Applications/`
     /// - The user previously chose "Don't Move"
@@ -74,13 +75,23 @@ public enum LetsMoveSwiftly {
     ///   - receiptURL: The App Store receipt URL. Defaults to `Bundle.main.appStoreReceiptURL`.
     ///   - fileManager: The file manager used to check file existence. Defaults to `.default`.
     ///   - defaults: The user defaults store for the "don't ask again" flag. Defaults to `.standard`.
+    ///   - isSandboxed: Whether the app is running in the macOS app sandbox. Defaults to runtime detection.
     /// - Returns: `true` if the app should prompt the user to move.
     public static func shouldOfferToMove(
         bundlePath: String = Bundle.main.bundlePath,
         receiptURL: URL? = Bundle.main.appStoreReceiptURL,
         fileManager: FileManager = .default,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        isSandboxed: Bool = ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil
     ) -> Bool {
+        // Sandboxed apps cannot perform the file operations needed to move themselves.
+        // This covers App Store builds, development builds with sandbox enabled, and any
+        // other sandboxed context. The admin-privilege fallback (NSAppleScript) is also
+        // blocked by the sandbox, so there's no point in prompting.
+        if isSandboxed {
+            return false
+        }
+
         // App Store installations always land in /Applications — no prompt needed.
         // We check that the receipt file actually exists on disk, not just the URL property,
         // because non-App Store builds may still have a receiptURL that points nowhere.

--- a/Tests/LetsMoveSwiftlyTests/MoveDecisionTests.swift
+++ b/Tests/LetsMoveSwiftlyTests/MoveDecisionTests.swift
@@ -16,6 +16,30 @@ final class MoveDecisionTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - shouldOfferToMove: Sandbox Detection
+
+    func testSkipsWhenRunningInSandbox() {
+        let result = LetsMoveSwiftly.shouldOfferToMove(
+            bundlePath: "/Users/test/Downloads/MyApp.app",
+            receiptURL: nil,
+            defaults: defaults,
+            isSandboxed: true
+        )
+
+        XCTAssertFalse(result, "Should skip when running in the app sandbox")
+    }
+
+    func testOffersToMoveWhenNotSandboxed() {
+        let result = LetsMoveSwiftly.shouldOfferToMove(
+            bundlePath: "/Users/test/Downloads/MyApp.app",
+            receiptURL: nil,
+            defaults: defaults,
+            isSandboxed: false
+        )
+
+        XCTAssertTrue(result, "Should offer to move when not sandboxed")
+    }
+
     // MARK: - shouldOfferToMove: App Store Detection
 
     func testSkipsWhenAppStoreReceiptExistsOnDisk() throws {
@@ -27,7 +51,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Downloads/MyApp.app",
             receiptURL: temporaryReceipt,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertFalse(result, "Should skip when App Store receipt exists on disk")
@@ -39,7 +64,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Downloads/MyApp.app",
             receiptURL: missingReceipt,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertTrue(result, "Should offer to move when receipt URL is set but file doesn't exist")
@@ -49,7 +75,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Downloads/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertTrue(result, "Should offer to move when receipt URL is nil")
@@ -61,7 +88,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Applications/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertFalse(result, "Should skip when already in /Applications")
@@ -71,7 +99,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Applications/Utilities/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertFalse(result, "Should skip when in /Applications subfolder")
@@ -83,7 +112,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: userApplicationsPath,
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertFalse(result, "Should skip when in ~/Applications")
@@ -97,7 +127,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Downloads/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertFalse(result, "Should skip when user previously chose 'Don't Move'")
@@ -109,7 +140,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Downloads/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertTrue(result, "Should offer to move when in Downloads")
@@ -119,7 +151,8 @@ final class MoveDecisionTests: XCTestCase {
         let result = LetsMoveSwiftly.shouldOfferToMove(
             bundlePath: "/Users/test/Desktop/MyApp.app",
             receiptURL: nil,
-            defaults: defaults
+            defaults: defaults,
+            isSandboxed: false
         )
 
         XCTAssertTrue(result, "Should offer to move when on Desktop")


### PR DESCRIPTION
## Summary
- Sandboxed apps cannot move themselves to `/Applications/` — both FileManager operations and the NSAppleScript admin-privilege fallback are blocked by the sandbox
- Added runtime sandbox detection via `APP_SANDBOX_CONTAINER_ID` environment variable to `shouldOfferToMove()`
- The `isSandboxed` parameter is injectable for testing, with a sensible default for production

## Test plan
- [x] `swift build` compiles cleanly
- [x] `swift test` — all 21 tests pass (2 new sandbox tests + 19 existing with explicit `isSandboxed: false`)
- [x] Run sandboxed app (e.g., MeetLink debug build) — move prompt should no longer appear
- [x] Run non-sandboxed app from Downloads — move prompt should still appear and work

🤖 Generated with [Claude Code](https://claude.com/claude-code)